### PR TITLE
feature: Implement button icon

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,8 +17,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
-interface ButtonIconProps extends ButtonProps {
+export interface ButtonIconProps extends ButtonProps {
   theme: DefaultTheme;
+  buttonSize?: number;
   onSafeClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
@@ -51,8 +52,8 @@ export const Button = (props: ButtonProps): ReactElement | null => {
   return <StyledLabelButton {...props} onClick={onSafeClick} />;
 };
 
-function ButtonIcon(props: ButtonIconProps): ReactElement | null {
-  const { loading, theme, icon, onSafeClick } = props;
+export function ButtonIcon(props: ButtonIconProps): ReactElement | null {
+  const { loading, buttonSize, theme, icon, onSafeClick } = props;
 
   if (!icon) return null;
 
@@ -61,11 +62,8 @@ function ButtonIcon(props: ButtonIconProps): ReactElement | null {
   }
 
   return (
-    <StyledIconButton>
-      {React.cloneElement(icon, {
-        ...props,
-        onClick: onSafeClick,
-      })}
+    <StyledIconButton {...props} buttonSize={buttonSize} onClick={onSafeClick}>
+      {React.cloneElement(icon)}
     </StyledIconButton>
   );
 }
@@ -139,10 +137,11 @@ const StyledLabelButton = styled.button`
   `}
 `;
 
-const StyledIconButton = styled.div`
+const StyledIconButton = styled.button<ButtonIconProps>`
+  all: unset;
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 24px;
-  height: 24px;
+  width: ${({ buttonSize }) => buttonSize ?? 24}px;
+  height: ${({ buttonSize }) => buttonSize ?? 24}px;
 `;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,9 +1,4 @@
-import React, {
-  ButtonHTMLAttributes,
-  MouseEvent,
-  ReactNode,
-  ReactElement,
-} from "react";
+import React, { ButtonHTMLAttributes, MouseEvent, ReactElement } from "react";
 import styled, {
   css,
   DefaultTheme,
@@ -14,24 +9,26 @@ import styled, {
 import { Spinner } from "../Spinner";
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: ReactNode;
+  children?: string | ReactElement;
+  icon?: ReactElement;
   variant: "filled" | "outlined";
   loading?: boolean;
   disabled?: boolean;
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
+interface ButtonIconProps extends ButtonProps {
+  theme: DefaultTheme;
+  onSafeClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+}
+
 /**
  * Primary UI component for user interaction
  */
-export const Button = ({
-  children,
-  onClick,
-  ...props
-}: ButtonProps): ReactElement => {
+export const Button = (props: ButtonProps): ReactElement | null => {
   const theme = useTheme();
 
-  const { loading, disabled } = props;
+  const { disabled, loading, onClick } = props;
 
   const onSafeClick = (event: MouseEvent<HTMLButtonElement>): void => {
     if (!disabled && onClick) {
@@ -39,20 +36,39 @@ export const Button = ({
     }
   };
 
+  if ("icon" in props) {
+    return <ButtonIcon {...props} theme={theme} onSafeClick={onSafeClick} />;
+  }
+
   if (loading) {
     return (
-      <StyledButton {...props} disabled>
+      <StyledLabelButton {...props} disabled>
         <Spinner color={theme.colors.icons.primary} />
-      </StyledButton>
+      </StyledLabelButton>
     );
   }
 
-  return (
-    <StyledButton onClick={onSafeClick} {...props}>
-      {children}
-    </StyledButton>
-  );
+  return <StyledLabelButton {...props} onClick={onSafeClick} />;
 };
+
+function ButtonIcon(props: ButtonIconProps): ReactElement | null {
+  const { loading, theme, icon, onSafeClick } = props;
+
+  if (!icon) return null;
+
+  if (loading) {
+    return <Spinner color={theme.colors.primary} />;
+  }
+
+  return (
+    <StyledIconButton>
+      {React.cloneElement(icon, {
+        ...props,
+        onClick: onSafeClick,
+      })}
+    </StyledIconButton>
+  );
+}
 
 const FILLED = (): FlattenInterpolation<ThemeProps<DefaultTheme>> => css`
   color: ${({ theme }) => theme.colors.button.filled.text};
@@ -94,7 +110,7 @@ const VARIANTS = {
   outlined: OUTLINED,
 };
 
-const StyledButton = styled.button`
+const StyledLabelButton = styled.button`
   ${({ variant }: ButtonProps) => css`
     display: flex;
     justify-content: center;
@@ -121,4 +137,12 @@ const StyledButton = styled.button`
 
     ${VARIANTS[variant]}
   `}
+`;
+
+const StyledIconButton = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 24px;
 `;

--- a/stories/components/Button.stories.tsx
+++ b/stories/components/Button.stories.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { Button as ButtonComponent, ButtonProps, ChevronIcon } from "../../src";
+import {
+  Button as ButtonComponent,
+  ButtonIcon,
+  ButtonIconProps,
+  ButtonProps,
+  ChevronIcon,
+} from "../../src";
 
 export default {
   title: "Components/Button",
@@ -35,8 +41,8 @@ export const Outlined: ComponentStory<typeof ButtonComponent> = (
   args: ButtonProps
 ) => <ButtonComponent {...args} variant={"outlined"} />;
 
-export const Icon: ComponentStory<typeof ButtonComponent> = (
-  args: ButtonProps
+export const Icon: ComponentStory<typeof ButtonIcon> = (
+  args: ButtonIconProps
 ) => <ButtonComponent {...args} />;
 
 Filled.args = {
@@ -63,4 +69,5 @@ Icon.args = {
   icon: <ChevronIcon />,
   loading: false,
   disabled: false,
+  buttonSize: 24,
 };

--- a/stories/components/Button.stories.tsx
+++ b/stories/components/Button.stories.tsx
@@ -1,6 +1,6 @@
-import React, { ReactElement } from "react";
-import { ComponentMeta } from "@storybook/react";
-import { Button as ButtonComponent, ButtonProps } from "../../src";
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Button as ButtonComponent, ButtonProps, ChevronIcon } from "../../src";
 
 export default {
   title: "Components/Button",
@@ -8,6 +8,16 @@ export default {
   argTypes: {
     children: {
       name: "label",
+    },
+    variant: {
+      table: {
+        disable: true,
+      },
+    },
+    icon: {
+      table: {
+        disable: true,
+      },
     },
     onClick: {
       table: {
@@ -17,17 +27,40 @@ export default {
   },
 } as ComponentMeta<typeof ButtonComponent>;
 
-export const Button = (args: ButtonProps): ReactElement => (
-  <ButtonComponent {...args} />
-);
+export const Filled: ComponentStory<typeof ButtonComponent> = (
+  args: ButtonProps
+) => <ButtonComponent {...args} variant={"filled"} />;
 
-Button.args = {
-  variant: "filled",
-  children: "Label",
+export const Outlined: ComponentStory<typeof ButtonComponent> = (
+  args: ButtonProps
+) => <ButtonComponent {...args} variant={"outlined"} />;
+
+export const Icon: ComponentStory<typeof ButtonComponent> = (
+  args: ButtonProps
+) => <ButtonComponent {...args} />;
+
+Filled.args = {
+  children: "Filled Button",
   loading: false,
   disabled: false,
   style: {
     width: 220,
     height: 40,
   },
+};
+
+Outlined.args = {
+  children: "Outlined Button",
+  loading: false,
+  disabled: false,
+  style: {
+    width: 220,
+    height: 40,
+  },
+};
+
+Icon.args = {
+  icon: <ChevronIcon />,
+  loading: false,
+  disabled: false,
 };


### PR DESCRIPTION
Follow up on https://github.com/Major-Eth/yearn-web-lib/pull/21#r820069331

We've decided to implement the clicking logic for icons in the `Button` component rather than adding too many smarts to the icons.

- Adds a new prop to the `Button`; `icon`. If that's given, then it will render the icon with the button props.