### PR TITLE
refactor(Banner): Add button icon to `Banner`'s chevron and crossmark

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -42,9 +42,7 @@ export const Banner = ({
         <StyledHeading2 bold>
           {details?.[current]?.heading || ""}
         </StyledHeading2>
-        <span onClick={handleClose}>
-          <Icon.CrossMark />
-        </span>
+        <Button.Icon icon={<Icon.CrossMark />} onClick={handleClose} />
       </HeaderContainer>
       {details[current].content}
       <BannerControls
@@ -96,6 +94,7 @@ const BannerControls = ({
 };
 
 const BannerContainer = styled.section`
+  color: ${({ theme }) => theme.colors.primary};
   background: ${({ theme }) => theme.colors.backgroundVariant};
   border: 2px solid ${({ theme }) => theme.colors.primary};
   box-sizing: border-box;
@@ -112,7 +111,6 @@ const ControlsContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  color: ${({ theme }) => theme.colors.primary};
 `;
 
 const StyledHeading2 = styled(Heading2)`

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement, useState } from "react";
 import styled from "styled-components";
 import { Icon } from "..";
 import { Heading2, Text } from "../../typography";
+import { Button } from "../Button";
 import { IconDirection } from "../Icon/Direction";
 
 export interface BannerDetailsProps {
@@ -77,22 +78,19 @@ const BannerControls = ({
     }
   };
 
-  // TODO: we possibly need to add IconButton that replaces span and also supports disabled state
   return (
     <ControlsContainer>
-      <span onClick={handleLeftChevronClick}>
-        <Icon.Chevron
-          direction={IconDirection.Left}
-          // disabled={isFirstBanner}
-        />
-      </span>
+      <Button.Icon
+        icon={<Icon.Chevron direction={IconDirection.Left} />}
+        onClick={handleLeftChevronClick}
+        disabled={isFirstBanner}
+      />
       <StyledText bold>{`${current + 1}/${numberOfBanners}`}</StyledText>
-      <span onClick={handleRightChevronClick}>
-        <Icon.Chevron
-          direction={IconDirection.Right}
-          // disabled={isLastBanner}
-        />
-      </span>
+      <Button.Icon
+        icon={<Icon.Chevron direction={IconDirection.Right} />}
+        onClick={handleRightChevronClick}
+        disabled={isLastBanner}
+      />
     </ControlsContainer>
   );
 };
@@ -114,6 +112,7 @@ const ControlsContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  color: ${({ theme }) => theme.colors.primary};
 `;
 
 const StyledHeading2 = styled(Heading2)`

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,10 +17,9 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
-export interface ButtonIconProps extends ButtonProps {
-  theme: DefaultTheme;
+export interface ButtonIconProps extends Omit<ButtonProps, "variant"> {
   buttonSize?: number;
-  onSafeClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
 /**
@@ -37,10 +36,6 @@ export const Button = (props: ButtonProps): ReactElement | null => {
     }
   };
 
-  if ("icon" in props) {
-    return <ButtonIcon {...props} theme={theme} onSafeClick={onSafeClick} />;
-  }
-
   if (loading) {
     return (
       <StyledLabelButton {...props} disabled>
@@ -52,10 +47,18 @@ export const Button = (props: ButtonProps): ReactElement | null => {
   return <StyledLabelButton {...props} onClick={onSafeClick} />;
 };
 
-export function ButtonIcon(props: ButtonIconProps): ReactElement | null {
-  const { loading, buttonSize, theme, icon, onSafeClick } = props;
+Button.Icon = function ButtonIcon(props: ButtonIconProps): ReactElement | null {
+  const theme = useTheme();
+
+  const { loading, buttonSize, icon, disabled, onClick } = props;
 
   if (!icon) return null;
+
+  const onSafeClick = (event: MouseEvent<HTMLButtonElement>): void => {
+    if (!disabled && onClick) {
+      onClick(event);
+    }
+  };
 
   if (loading) {
     return <Spinner color={theme.colors.primary} />;
@@ -66,7 +69,7 @@ export function ButtonIcon(props: ButtonIconProps): ReactElement | null {
       {React.cloneElement(icon)}
     </StyledIconButton>
   );
-}
+};
 
 const FILLED = (): FlattenInterpolation<ThemeProps<DefaultTheme>> => css`
   color: ${({ theme }) => theme.colors.button.filled.text};
@@ -144,4 +147,10 @@ const StyledIconButton = styled.button<ButtonIconProps>`
   align-items: center;
   width: ${({ buttonSize }) => buttonSize ?? 24}px;
   height: ${({ buttonSize }) => buttonSize ?? 24}px;
+  cursor: pointer;
+
+  &:disabled {
+    color: ${({ theme }) => theme.colors.button.disabled.text};
+    cursor: not-allowed;
+  }
 `;

--- a/stories/components/Button.stories.tsx
+++ b/stories/components/Button.stories.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import {
   Button as ButtonComponent,
-  ButtonIcon,
   ButtonIconProps,
   ButtonProps,
-  ChevronIcon,
 } from "../../src";
+import { Icon as IconComponent } from "../../src/components";
+import { IconDirection } from "../../src/components/Icon/Direction";
 
 export default {
   title: "Components/Button",
@@ -41,9 +41,9 @@ export const Outlined: ComponentStory<typeof ButtonComponent> = (
   args: ButtonProps
 ) => <ButtonComponent {...args} variant={"outlined"} />;
 
-export const Icon: ComponentStory<typeof ButtonIcon> = (
+export const Icon: ComponentStory<typeof ButtonComponent.Icon> = (
   args: ButtonIconProps
-) => <ButtonComponent {...args} />;
+) => <ButtonComponent.Icon {...args} />;
 
 Filled.args = {
   children: "Filled Button",
@@ -66,7 +66,7 @@ Outlined.args = {
 };
 
 Icon.args = {
-  icon: <ChevronIcon />,
+  icon: <IconComponent.Chevron direction={IconDirection.Left} />,
   loading: false,
   disabled: false,
   buttonSize: 24,


### PR DESCRIPTION
We've changed the way the icons act as button with the new `Button.Icon`, this PR will add those buttons to the `Banner` component.

I had to change a little bit the button icon component, realised that we don't need the variant, so easier to create a new component rather than try to fit it in the regular button.